### PR TITLE
Update distance of "Far far away" from 1000 to 3000 km

### DIFF
--- a/src/Components/Provider.vue
+++ b/src/Components/Provider.vue
@@ -159,8 +159,8 @@ export default {
 				})
 		},
 		distance() {
-			// Don't display distance bigger than 1000km
-			if (this.locations[0].score <= 1000) {
+			// Don't display distance bigger than 3000km
+			if (this.locations[0].score <= 3000) {
 				// rounding to the hundred
 				return '< ' + Math.round(this.locations[0].score / 100) * 100 + 'km'
 			} else {


### PR DESCRIPTION
In Southeast Asia 1000km is nothing. A provider in Kuala Lumpur (Malaysia) shouldn’t show up as "Far far away" when you are in Yogyakarta (Indonesia) in a neighboring country. ;)