### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -163,7 +163,7 @@ export default {
 		await this.getProviders()
 
 		// select if in url
-		const hash = decodeURIComponent(window.location.hash.substr(1))
+		const hash = decodeURIComponent(window.location.hash.slice(1))
 		if (hash.trim() !== '') {
 			const providerIndex = this.providers.findIndex(prov => prov.name.toLowerCase().replace(/ /g, '_') === hash)
 			if (providerIndex > -1) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.