### PR TITLE
feature: Add support for V3 flow in registration process

### DIFF
--- a/src/Register.vue
+++ b/src/Register.vue
@@ -133,6 +133,8 @@ export default {
 			error: false,
 			// is the request made by an api
 			ocsapi: false,
+			// the new V3 flow - used by the desktop client
+			flow: false,
 			officialApps: {},
 			coreApps: [],
 			// agreed to the tos ?
@@ -176,6 +178,12 @@ export default {
 		this.ocsapi = window.register?.dataset?.ocsapi === '1'
 		if (this.ocsapi) {
 			console.debug('This registration will be treated as an OCS API request', this.ocsapi)
+		}
+
+		// is this desktop client V3 request?
+		this.flow = window.register?.dataset?.flow || false
+		if (this.flow) {
+			console.debug('This registration will be treated as a V3 request for the desktop client', this.flow)
 		}
 
 		// merge server translations into local ones
@@ -259,6 +267,7 @@ export default {
 				location,
 				ocsapi: this.ocsapi,
 				subscribe,
+				flow: this.flow,
 			})
 				.then(response => {
 					this.created = true


### PR DESCRIPTION
**Background**

- The existing Simple-Signup-Process relied on the internal QTWebEngine. This is not available as of macOS sandboxing anymore. 
- Additionally, the QTWebEngine accounted for 50% of the whole desktop client (download & install size)

**Overview**

- The Simple-Signup-Process now opens nextcloud.com with the default browser and adds a flow=V3 url parameter
- This parameter is forwarded from the website ([nextcloud-register](https://github.com/nextcloud/nextcloud-register/pull/704)) to the website backend ([nextcloud-theme](https://github.com/nextcloud/nextcloud-theme/pull/110)) and then to the Nextcloud of the provider ([prefered_providers](https://github.com/nextcloud/preferred_providers/pull/151))
- The existing flow based on `ocsapirequest` (old desktop clients & mobile clients) is not touched. In this case, the Nextcloud will return a `nc://login/server:{server}&user:{email}&password:{appPassword}` response
- When a request arrives with `flow=V3`, the user is logged in in the webUI and additionally, a `nc://login/server:{server}` response is triggered
- This response will trigger the existing V2 flow in the client and jump to the "grant access" section right away, without the user needing to perform any additional action


**Changes to desktop**

- Added a central nc:// URI dispatcher for routing supported actions.
- Kept existing local edit handling under nc://open/....
- Added quick login handling for nc://login/server:{server}
- The login URI now starts the Flow v2 account login directly with the supplied server URL.
- Added validation for malformed or unsupported URI actions so they are rejected before falling through to local-edit handling.
- Added parser coverage for valid login URLs, invalid login URLs, local-edit URLs, and unsupported actions.
- Added macOS URI dispatch logging to make it visible when an nc:// URL reaches the client.
- Updated the setup wizard so an incoming login URI restarts an already-open wizard into the Flow v2 login page instead of only raising the existing window.
- Fixed the provider signup waiting page text so the status text wraps within the available window width.

**Dependent PRs:**

- Website: [prefered_providers](https://github.com/nextcloud/preferred_providers/pull/151)
- Website backend [nextcloud-theme](https://github.com/nextcloud/nextcloud-theme/pull/110)
- Nextcloud: [nextcloud-register](https://github.com/nextcloud/nextcloud-register/pull/704)
- Desktop: [client](https://github.com/nextcloud/desktop/pull/9969)

On the nextcloud.com wordpress, the following will be added in `/inc/shortcodes.php`: 
`data-flow="<?php echo htmlspecialchars($_GET['flow'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"`